### PR TITLE
Make linguist ignore *.ipynb files

### DIFF
--- a/Python/.gitattributes
+++ b/Python/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
# Description

Making linguist ignore *.ipynb files for language classification can prevent GitHub from incorrectly classifying this repo as a Jupyter Notebook repo.

Fixes #809

## Type of change

Added a .gitattributes file in the Python directory.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines(Clean Code) of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works